### PR TITLE
Fix Jest failing due to ESM react‑router

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,12 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
+// Use a manual mock for react-router-dom located in __mocks__
+jest.mock("react-router-dom");
+
+test("renders Flashcard Decks heading", async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = await screen.findByText(/Flashcard Decks/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/__mocks__/react-router-dom.js
+++ b/src/__mocks__/react-router-dom.js
@@ -1,0 +1,14 @@
+const React = require("react");
+
+module.exports = {
+  BrowserRouter: ({ children }) => React.createElement(React.Fragment, null, children),
+  Routes: ({ children }) => {
+    const firstChild = React.Children.toArray(children)[0];
+    return React.createElement(React.Fragment, null, firstChild);
+  },
+  Route: ({ element }) => element,
+  useParams: () => ({}),
+  Link: React.forwardRef(({ children, to }, ref) =>
+    React.createElement("a", { href: to, ref }, children)
+  ),
+};


### PR DESCRIPTION
## Summary
- add manual mock for `react-router-dom`
- update `App.test.js` to use the manual mock and wait for async rendering

## Testing
- `CI=1 npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851eed4f1c0832aa7ff0daf656f0110